### PR TITLE
Add interactive wizard mode and Sanctum authentication scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.2.0] - 2026-03-15
 
 ### Added
+- **Interactive wizard** -- `--interactive` flag launches a step-by-step guided setup: entity name, fields (with type, nullable, unique, default), relationships, options, preview, and confirmation
+- **Sanctum authentication** -- `--auth` flag scaffolds a complete auth system: AuthController (register/login/logout/user), LoginRequest, RegisterRequest, auth routes, and wraps API resources in `auth:sanctum` middleware
 - **Auto-generated tests** -- Feature tests (CRUD endpoints) and Unit tests (Service layer) are now generated for every entity
 - **Postman collection export** -- `--postman` flag generates a ready-to-import Postman v2.1 JSON collection with all endpoints and sample data
 - **Soft Deletes support** -- `--soft-deletes` flag adds the SoftDeletes trait, migration column, restore/forceDelete controller and service methods, and dedicated routes
@@ -15,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Complete generator implementations** -- All 9 generator classes (Controller, DTO, Factory, Migration, Policy, Request, Resource, Seeder, Service) are now fully implemented following the AbstractGenerator pattern
 - **FeatureTestGenerator** and **UnitTestGenerator** for automatic test scaffolding
 - **PostmanExporter** service for collection generation
-- New stubs: `test.feature.stub`, `test.unit.stub`
+- **AuthGenerator** service for Sanctum auth scaffolding
+- `unique` and `default` field constraints support in FieldDefinition, MigrationGenerator, and RequestGenerator
+- New stubs: `test.feature.stub`, `test.unit.stub`, `auth.controller.stub`, `auth.login-request.stub`, `auth.register-request.stub`
 
 ### Fixed
 - **StubLoader placeholder matching** -- Fixed a bug where `{{placeholder}}` syntax in stubs was not matched correctly (single vs double braces)
@@ -25,10 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **MakeApiCommand** is now the active command (replaces the legacy MakeApi command)
-- Command signature updated: `make:fullapi {name?} {--fields=} {--soft-deletes} {--postman}`
-- ServiceProvider now registers all 12 generators (including test generators)
+- Command signature updated: `make:fullapi {name?} {--fields=} {--soft-deletes} {--postman} {--auth} {--interactive}`
+- ServiceProvider now registers all 12 generators (including test generators) plus AuthGenerator
 - Generated controllers now accept `Request $request` in `index()` for filtering
 - Generated services now accept `array $filters` in `getAll()` method
+- Generated migrations now support `->unique()` and `->default()` modifiers
+- Generated validation rules now include `unique` constraint when applicable
 - `deleteCompleteApi()` now also cleans up generated test files
 - PHPStan configuration cleaned up (removed deprecated options)
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,26 @@ php artisan make:fullapi Post --fields="title:string,content:text" --postman
 
 Generates a `postman_collection.json` at the project root, ready to import. Each entity gets a folder with List, Create, Show, Update, and Delete requests pre-configured with sample data.
 
+### With Sanctum authentication
+
+```bash
+php artisan make:fullapi Post --fields="title:string,content:text" --auth
+```
+
+This scaffolds a complete Sanctum-based auth system: `AuthController` (register, login, logout, user), `LoginRequest`, `RegisterRequest`, auth routes, and wraps your API resource routes inside `auth:sanctum` middleware.
+
+### Interactive wizard
+
+```bash
+php artisan make:fullapi --interactive
+```
+
+A step-by-step guided setup that lets you define the entity name, add fields one by one (with type, nullable, unique, and default value options), configure relationships, and preview everything before generation.
+
 ### All options combined
 
 ```bash
-php artisan make:fullapi Post --fields="title:string,content:text" --soft-deletes --postman
+php artisan make:fullapi Post --fields="title:string,content:text" --soft-deletes --postman --auth
 ```
 
 ### Bulk generation from JSON
@@ -120,7 +136,7 @@ php artisan delete:fullapi
 ## Command reference
 
 ```
-php artisan make:fullapi {name?} {--fields=} {--soft-deletes} {--postman}
+php artisan make:fullapi {name?} {--fields=} {--soft-deletes} {--postman} {--auth} {--interactive}
 ```
 
 | Argument / Option | Description |
@@ -129,6 +145,8 @@ php artisan make:fullapi {name?} {--fields=} {--soft-deletes} {--postman}
 | `--fields` | Field definitions in `name:type` format, comma-separated. |
 | `--soft-deletes` | Add SoftDeletes trait, migration column, restore/forceDelete endpoints. |
 | `--postman` | Export a Postman v2.1 collection after generation. |
+| `--auth` | Scaffold Sanctum authentication (AuthController, requests, routes, middleware). |
+| `--interactive` | Launch the step-by-step wizard for guided entity creation. |
 
 ---
 
@@ -341,6 +359,60 @@ The `--postman` flag generates a `postman_collection.json` file at the project r
 - A `base_url` variable (defaults to `http://localhost:8000/api`)
 
 Import the file directly into Postman to start testing immediately.
+
+---
+
+## Sanctum authentication
+
+The `--auth` flag scaffolds a complete token-based authentication system using Laravel Sanctum:
+
+**Generated files:**
+
+- `app/Http/Controllers/AuthController.php` -- register, login, logout, user endpoints
+- `app/Http/Requests/LoginRequest.php` -- email + password validation
+- `app/Http/Requests/RegisterRequest.php` -- name, email, password + confirmation validation
+
+**Generated routes:**
+
+```php
+// Public
+POST /api/register
+POST /api/login
+
+// Protected (auth:sanctum)
+POST /api/logout
+GET  /api/user
+
+// Your API resources are also wrapped in auth:sanctum
+GET  /api/posts          (requires token)
+POST /api/posts          (requires token)
+// ...
+```
+
+After running with `--auth`, install Sanctum if not already present:
+
+```bash
+composer require laravel/sanctum
+php artisan vendor:publish --provider="Laravel\Sanctum\SanctumServiceProvider"
+php artisan migrate
+```
+
+Add the `HasApiTokens` trait to your `User` model, and your API is secured.
+
+---
+
+## Interactive mode
+
+The `--interactive` flag launches a step-by-step wizard that guides you through entity creation:
+
+1. **Entity name** -- enter the model name in PascalCase
+2. **Fields** -- add fields one by one, choosing type, nullable, unique, and default value for each
+3. **Relationships** -- optionally add belongsTo, hasMany, hasOne, or belongsToMany relations
+4. **Options** -- enable soft deletes, Sanctum auth, Postman export
+5. **Preview** -- review the full entity definition and file list before confirming
+6. **Generate** -- confirm and generate all files
+
+This mode is ideal for developers who prefer a guided experience or want to configure field constraints (unique, defaults) that aren't available in the `--fields` string syntax.
 
 ---
 

--- a/src/Console/Commands/MakeApiCommand.php
+++ b/src/Console/Commands/MakeApiCommand.php
@@ -7,6 +7,7 @@ namespace nameless\CodeGenerator\Console\Commands;
 use Illuminate\Console\Command;
 use nameless\CodeGenerator\Contracts\ApiGenerationServiceInterface;
 use nameless\CodeGenerator\Services\PostmanExporter;
+use nameless\CodeGenerator\Services\AuthGenerator;
 use nameless\CodeGenerator\ValueObjects\EntityDefinition;
 use nameless\CodeGenerator\ValueObjects\FieldDefinition;
 use nameless\CodeGenerator\ValueObjects\RelationshipDefinition;
@@ -17,12 +18,13 @@ use Illuminate\Support\Facades\File;
 
 class MakeApiCommand extends Command
 {
-    protected $signature = 'make:fullapi {name?} {--fields=} {--soft-deletes} {--postman}';
+    protected $signature = 'make:fullapi {name?} {--fields=} {--soft-deletes} {--postman} {--auth} {--interactive}';
     protected $description = 'Generate a complete API including model, migration, controller, resource, request, factory, seeder, DTO, service, policy, and tests';
 
     public function __construct(
         private readonly ApiGenerationServiceInterface $apiGenerationService,
-        private readonly PostmanExporter $postmanExporter
+        private readonly PostmanExporter $postmanExporter,
+        private readonly AuthGenerator $authGenerator
     ) {
         parent::__construct();
     }
@@ -30,6 +32,16 @@ class MakeApiCommand extends Command
     public function handle(): int
     {
         try {
+            // Handle auth scaffolding
+            if ($this->option('auth')) {
+                $this->scaffoldAuth();
+            }
+
+            // Interactive mode
+            if ($this->option('interactive')) {
+                return $this->handleInteractiveGeneration();
+            }
+
             $name = $this->argument('name');
 
             if (empty($name)) {
@@ -45,6 +57,213 @@ class MakeApiCommand extends Command
             return self::FAILURE;
         }
     }
+
+    // ─── Interactive wizard ─────────────────────────────────────────────
+
+    private function handleInteractiveGeneration(): int
+    {
+        $this->info('Laravel API Generator - Interactive Mode');
+        $this->line('─────────────────────────────────────────');
+        $this->newLine();
+
+        // 1. Entity name
+        $name = $this->ask('Entity name (PascalCase)');
+        if (empty($name)) {
+            $this->error('Entity name is required.');
+            return self::FAILURE;
+        }
+        $name = ucfirst($name);
+
+        // 2. Fields
+        $fields = $this->collectFields();
+        if ($fields->isEmpty()) {
+            $this->error('At least one field is required.');
+            return self::FAILURE;
+        }
+
+        // 3. Relationships
+        $relationships = $this->collectRelationships();
+
+        // 4. Options
+        $softDeletes = $this->confirm('Enable soft deletes?', false);
+        $withAuth = !$this->option('auth') && $this->confirm('Add Sanctum authentication?', false);
+        $withPostman = !$this->option('postman') && $this->confirm('Export Postman collection?', false);
+
+        // 5. Preview
+        $this->displayPreview($name, $fields, $relationships, $softDeletes, $withAuth || $this->option('auth'));
+
+        if (!$this->confirm('Confirm generation?', true)) {
+            $this->warn('Generation cancelled.');
+            return self::SUCCESS;
+        }
+
+        // 6. Generate
+        if ($withAuth || $this->option('auth')) {
+            $this->scaffoldAuth();
+        }
+
+        $definition = new EntityDefinition(
+            name: $name,
+            fields: $fields,
+            relationships: $relationships,
+            options: ['soft_deletes' => $softDeletes]
+        );
+
+        $this->info("Generating complete API for: {$name}");
+        $this->apiGenerationService->generateCompleteApi($definition);
+
+        if ($withAuth || $this->option('auth')) {
+            $this->authGenerator->wrapRoutesInAuthMiddleware();
+        }
+
+        $this->displayGeneratedFiles($definition);
+
+        if ($withPostman || $this->option('postman')) {
+            $outputPath = base_path('postman_collection.json');
+            $this->postmanExporter->export(collect([$definition]), $outputPath);
+            $this->info("Postman collection exported to: {$outputPath}");
+        }
+
+        $this->info('API generation completed successfully!');
+        return self::SUCCESS;
+    }
+
+    private function collectFields(): Collection
+    {
+        $fields = collect();
+        $allowedTypes = ['string', 'text', 'integer', 'int', 'bigint', 'boolean', 'bool', 'float', 'decimal', 'json', 'date', 'datetime', 'timestamp', 'uuid'];
+
+        $this->newLine();
+        $this->info('Define fields (press Enter with empty name to finish):');
+
+        while (true) {
+            $fieldName = $this->ask('  Field name');
+            if (empty($fieldName)) {
+                break;
+            }
+
+            $type = $this->choice('  Type', $allowedTypes, 0);
+            $nullable = $this->confirm('  Nullable?', true);
+            $unique = $this->confirm('  Unique?', false);
+
+            $default = null;
+            if ($this->confirm('  Has default value?', false)) {
+                $default = $this->ask('  Default value');
+            }
+
+            $fields->push(new FieldDefinition(
+                name: $fieldName,
+                type: $type,
+                nullable: $nullable,
+                unique: $unique,
+                default: $default
+            ));
+
+            $this->line("    Added: {$fieldName} ({$type})" .
+                ($nullable ? '' : ', required') .
+                ($unique ? ', unique' : '') .
+                ($default !== null ? ", default: {$default}" : ''));
+            $this->newLine();
+        }
+
+        return $fields;
+    }
+
+    private function collectRelationships(): Collection
+    {
+        $relationships = collect();
+
+        $this->newLine();
+        if (!$this->confirm('Add relationships?', false)) {
+            return $relationships;
+        }
+
+        $types = [
+            'belongsTo' => 'manyToOne',
+            'hasMany' => 'oneToMany',
+            'hasOne' => 'oneToOne',
+            'belongsToMany' => 'manyToMany',
+        ];
+
+        while (true) {
+            $typeChoice = $this->choice('  Relationship type', array_keys($types));
+            $relatedModel = $this->ask('  Related model (PascalCase)');
+
+            if (empty($relatedModel)) {
+                break;
+            }
+
+            $role = $this->ask('  Role/method name', lcfirst($relatedModel));
+
+            $relationships->push(new RelationshipDefinition(
+                type: $types[$typeChoice],
+                relatedModel: ucfirst($relatedModel),
+                role: $role
+            ));
+
+            $this->line("    Added: {$typeChoice} -> {$relatedModel} (as {$role})");
+            $this->newLine();
+
+            if (!$this->confirm('  Add another relationship?', false)) {
+                break;
+            }
+        }
+
+        return $relationships;
+    }
+
+    private function displayPreview(
+        string $name,
+        Collection $fields,
+        Collection $relationships,
+        bool $softDeletes,
+        bool $withAuth
+    ): void {
+        $this->newLine();
+        $this->line('── Preview ──────────────────────────────────────');
+        $this->line("  Entity:     {$name}");
+
+        $this->line('  Fields:');
+        $fields->each(function (FieldDefinition $field) {
+            $constraints = [];
+            if (!$field->nullable) {
+                $constraints[] = 'required';
+            }
+            if ($field->unique) {
+                $constraints[] = 'unique';
+            }
+            if ($field->default !== null) {
+                $constraints[] = "default: {$field->default}";
+            }
+            $extra = !empty($constraints) ? ' (' . implode(', ', $constraints) . ')' : '';
+            $this->line("              {$field->name}: {$field->type}{$extra}");
+        });
+
+        if ($relationships->isNotEmpty()) {
+            $this->line('  Relations:');
+            $relationships->each(function (RelationshipDefinition $rel) {
+                $this->line("              {$rel->getEloquentMethod()} -> {$rel->relatedModel} (as {$rel->role})");
+            });
+        }
+
+        $options = [];
+        if ($softDeletes) {
+            $options[] = 'soft deletes';
+        }
+        if ($withAuth) {
+            $options[] = 'sanctum auth';
+        }
+        if (!empty($options)) {
+            $this->line('  Options:    ' . implode(', ', $options));
+        }
+
+        $this->newLine();
+        $this->line('  Files to generate: 12 files + route');
+        $this->line('─────────────────────────────────────────────────');
+        $this->newLine();
+    }
+
+    // ─── Standard generation modes ──────────────────────────────────────
 
     private function handleJsonGeneration(): int
     {
@@ -62,6 +281,10 @@ class MakeApiCommand extends Command
         $this->info("Generating APIs from JSON data...");
         $this->apiGenerationService->generateFromJson($jsonData);
 
+        if ($this->option('auth')) {
+            $this->authGenerator->wrapRoutesInAuthMiddleware();
+        }
+
         $this->info("API generation completed successfully!");
 
         if ($this->option('postman')) {
@@ -77,6 +300,7 @@ class MakeApiCommand extends Command
 
         if (!$fieldsOption) {
             $this->error('You must specify fields with the --fields option. Example: --fields="name:string,age:integer"');
+            $this->line('Or use --interactive for guided setup.');
             return self::FAILURE;
         }
 
@@ -91,6 +315,10 @@ class MakeApiCommand extends Command
 
         $this->apiGenerationService->generateCompleteApi($definition);
 
+        if ($this->option('auth')) {
+            $this->authGenerator->wrapRoutesInAuthMiddleware();
+        }
+
         $this->displayGeneratedFiles($definition);
 
         if ($this->option('postman')) {
@@ -101,6 +329,22 @@ class MakeApiCommand extends Command
 
         $this->info("API generation completed successfully!");
         return self::SUCCESS;
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private function scaffoldAuth(): void
+    {
+        $this->info('Scaffolding Sanctum authentication...');
+        $files = $this->authGenerator->generate();
+        foreach ($files as $file) {
+            $this->line("  - " . str_replace(base_path() . DIRECTORY_SEPARATOR, '', $file));
+        }
+        $this->info('Auth scaffolding complete. Make sure laravel/sanctum is installed:');
+        $this->line('  composer require laravel/sanctum');
+        $this->line('  php artisan vendor:publish --provider="Laravel\\Sanctum\\SanctumServiceProvider"');
+        $this->line('  php artisan migrate');
+        $this->newLine();
     }
 
     private function createEntityDefinition(string $name, array $fieldsArray): EntityDefinition

--- a/src/EntitiesGenerator/MigrationGenerator.php
+++ b/src/EntitiesGenerator/MigrationGenerator.php
@@ -46,8 +46,17 @@ class MigrationGenerator extends AbstractGenerator
     {
         $fields = $definition->fields->map(function (FieldDefinition $field) {
             $dbType = $field->getDatabaseType();
-            $nullable = $field->nullable ? '->nullable()' : '';
-            return "            \$table->{$dbType}('{$field->name}'){$nullable};";
+            $modifiers = '';
+            if ($field->nullable) {
+                $modifiers .= '->nullable()';
+            }
+            if ($field->unique) {
+                $modifiers .= '->unique()';
+            }
+            if ($field->default !== null) {
+                $modifiers .= "->default('{$field->default}')";
+            }
+            return "            \$table->{$dbType}('{$field->name}'){$modifiers};";
         })->toArray();
 
         return implode("\n", $fields);

--- a/src/Providers/CodeGeneratorServiceProvider.php
+++ b/src/Providers/CodeGeneratorServiceProvider.php
@@ -13,6 +13,7 @@ use nameless\CodeGenerator\Console\Commands\InstallPackageCommand;
 use nameless\CodeGenerator\Contracts\ApiGenerationServiceInterface;
 use nameless\CodeGenerator\Services\ApiGenerationService;
 use nameless\CodeGenerator\Services\PostmanExporter;
+use nameless\CodeGenerator\Services\AuthGenerator;
 use nameless\CodeGenerator\Support\JsonParser;
 use nameless\CodeGenerator\Support\StubLoader;
 use nameless\CodeGenerator\EntitiesGenerator\ModelGeneratorRefactored;
@@ -63,6 +64,9 @@ class CodeGeneratorServiceProvider extends ServiceProvider
 
         // Register PostmanExporter
         $this->app->singleton(PostmanExporter::class);
+
+        // Register AuthGenerator
+        $this->app->singleton(AuthGenerator::class);
 
         // Register main API generation service
         $this->app->singleton(ApiGenerationServiceInterface::class, function ($app) {

--- a/src/Services/AuthGenerator.php
+++ b/src/Services/AuthGenerator.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace nameless\CodeGenerator\Services;
+
+use nameless\CodeGenerator\Support\StubLoader;
+use Illuminate\Support\Facades\File;
+
+class AuthGenerator
+{
+    public function __construct(
+        private readonly StubLoader $stubLoader
+    ) {}
+
+    public function generate(): array
+    {
+        $generatedFiles = [];
+
+        // Generate AuthController
+        $controllerPath = app_path('Http/Controllers/AuthController.php');
+        $this->ensureDirectoryExists($controllerPath);
+        File::put($controllerPath, $this->stubLoader->load('auth.controller'));
+        $generatedFiles[] = $controllerPath;
+
+        // Generate LoginRequest
+        $loginRequestPath = app_path('Http/Requests/LoginRequest.php');
+        $this->ensureDirectoryExists($loginRequestPath);
+        File::put($loginRequestPath, $this->stubLoader->load('auth.login-request'));
+        $generatedFiles[] = $loginRequestPath;
+
+        // Generate RegisterRequest
+        $registerRequestPath = app_path('Http/Requests/RegisterRequest.php');
+        $this->ensureDirectoryExists($registerRequestPath);
+        File::put($registerRequestPath, $this->stubLoader->load('auth.register-request'));
+        $generatedFiles[] = $registerRequestPath;
+
+        // Add auth routes
+        $this->generateAuthRoutes();
+
+        return $generatedFiles;
+    }
+
+    private function generateAuthRoutes(): void
+    {
+        $apiFilePath = base_path('routes/api.php');
+        $phpHeader = "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\nuse App\\Http\\Controllers\\AuthController;\n\n";
+
+        if (!File::exists($apiFilePath)) {
+            File::put($apiFilePath, $phpHeader);
+        }
+
+        $content = File::get($apiFilePath);
+
+        // Add AuthController import if missing
+        if (!str_contains($content, 'use App\\Http\\Controllers\\AuthController')) {
+            $content = str_replace(
+                "use Illuminate\\Support\\Facades\\Route;",
+                "use Illuminate\\Support\\Facades\\Route;\nuse App\\Http\\Controllers\\AuthController;",
+                $content
+            );
+            File::put($apiFilePath, $content);
+        }
+
+        // Add public auth routes
+        $authRoutes = <<<'ROUTES'
+
+// Authentication routes
+Route::post('register', [AuthController::class, 'register']);
+Route::post('login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('logout', [AuthController::class, 'logout']);
+    Route::get('user', [AuthController::class, 'user']);
+});
+ROUTES;
+
+        $content = File::get($apiFilePath);
+        if (!str_contains($content, "AuthController::class, 'register'")) {
+            File::append($apiFilePath, PHP_EOL . $authRoutes);
+        }
+    }
+
+    public function wrapRoutesInAuthMiddleware(): void
+    {
+        $apiFilePath = base_path('routes/api.php');
+
+        if (!File::exists($apiFilePath)) {
+            return;
+        }
+
+        $content = File::get($apiFilePath);
+
+        // Find existing apiResource lines that are NOT inside a middleware group
+        // and wrap them in auth:sanctum middleware
+        if (str_contains($content, "Route::middleware('auth:sanctum')->group(function ()")) {
+            // Middleware group already exists - move apiResource lines into it
+            $lines = explode("\n", $content);
+            $apiResourceLines = [];
+            $otherLines = [];
+
+            foreach ($lines as $line) {
+                if (str_contains($line, 'Route::apiResource(') && !str_contains($line, '//')) {
+                    $apiResourceLines[] = '    ' . trim($line);
+                } elseif (str_contains($line, 'Route::post(') && str_contains($line, 'restore')) {
+                    $apiResourceLines[] = '    ' . trim($line);
+                } elseif (str_contains($line, 'Route::delete(') && str_contains($line, 'force-delete')) {
+                    $apiResourceLines[] = '    ' . trim($line);
+                } else {
+                    $otherLines[] = $line;
+                }
+            }
+
+            if (!empty($apiResourceLines)) {
+                $content = implode("\n", $otherLines);
+                // Insert apiResource lines before the closing of the middleware group
+                $apiResourceBlock = implode("\n", $apiResourceLines);
+                $content = str_replace(
+                    "Route::middleware('auth:sanctum')->group(function () {\n    Route::post('logout', [AuthController::class, 'logout']);\n    Route::get('user', [AuthController::class, 'user']);\n});",
+                    "Route::middleware('auth:sanctum')->group(function () {\n    Route::post('logout', [AuthController::class, 'logout']);\n    Route::get('user', [AuthController::class, 'user']);\n\n{$apiResourceBlock}\n});",
+                    $content
+                );
+                File::put($apiFilePath, $content);
+            }
+        }
+    }
+
+    private function ensureDirectoryExists(string $filePath): void
+    {
+        $directory = dirname($filePath);
+
+        if (!File::isDirectory($directory)) {
+            File::makeDirectory($directory, 0755, true);
+        }
+    }
+}

--- a/src/ValueObjects/FieldDefinition.php
+++ b/src/ValueObjects/FieldDefinition.php
@@ -12,6 +12,7 @@ final readonly class FieldDefinition
         public string $name,
         public string $type,
         public bool $nullable = true,
+        public bool $unique = false,
         public ?string $default = null,
         public array $validationRules = [],
         public array $attributes = []
@@ -92,7 +93,14 @@ final readonly class FieldDefinition
             default => 'string'
         };
 
-        return $this->nullable ? "sometimes|{$rule}" : "required|{$rule}";
+        $prefix = $this->nullable ? 'sometimes' : 'required';
+        $rule = "{$prefix}|{$rule}";
+
+        if ($this->unique) {
+            $rule .= '|unique';
+        }
+
+        return $rule;
     }
 
     public function getFakeValue(): string

--- a/stubs/auth.controller.stub
+++ b/stubs/auth.controller.stub
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\LoginRequest;
+use App\Http\Requests\RegisterRequest;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(RegisterRequest $request): JsonResponse
+    {
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'user' => $user,
+            'token' => $token,
+        ], 201);
+    }
+
+    public function login(LoginRequest $request): JsonResponse
+    {
+        if (!Auth::attempt($request->only('email', 'password'))) {
+            return response()->json([
+                'message' => 'Invalid credentials.',
+            ], 401);
+        }
+
+        $token = Auth::user()->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'user' => Auth::user(),
+            'token' => $token,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.',
+        ]);
+    }
+
+    public function user(Request $request): JsonResponse
+    {
+        return response()->json($request->user());
+    }
+}

--- a/stubs/auth.login-request.stub
+++ b/stubs/auth.login-request.stub
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required|string|min:6',
+        ];
+    }
+}

--- a/stubs/auth.register-request.stub
+++ b/stubs/auth.register-request.stub
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:6|confirmed',
+        ];
+    }
+}


### PR DESCRIPTION
Interactive mode (--interactive):
- Step-by-step guided entity creation with prompts for name, fields, relationships, and options
- Field-level configuration: type, nullable, unique, default value
- Relationship wizard with all 4 Eloquent types
- Preview of entity definition and file list before generation

Sanctum authentication (--auth):
- Generates AuthController with register/login/logout/user endpoints
- Generates LoginRequest and RegisterRequest form requests
- Adds public auth routes and wraps API resources in auth:sanctum middleware group
- New AuthGenerator service and 3 auth stubs

Also adds unique and default field constraints to FieldDefinition, MigrationGenerator (->unique(), ->default()), and RequestGenerator.